### PR TITLE
Name must be comprised of letters or numbers.  

### DIFF
--- a/hanabi/forms.py
+++ b/hanabi/forms.py
@@ -2,7 +2,7 @@ import wtforms
 from flask_wtf import FlaskForm
 from wtforms.validators import DataRequired
 
-from hanabi.validators import ValidAccessToken
+from hanabi.validators import ValidAccessToken, ValidAsciiValues
 
 
 class CreateLobbyForm(FlaskForm):
@@ -10,14 +10,18 @@ class CreateLobbyForm(FlaskForm):
     Form for creating a new lobby.
     """
 
-    name = wtforms.StringField("Name", validators=[DataRequired()])
+    name = wtforms.StringField(
+        "Name", validators=[DataRequired(), ValidAsciiValues()]
+    )
 
 
 class JoinLobbyForm(FlaskForm):
     access_token = wtforms.StringField(
         "Access Token", validators=[DataRequired(), ValidAccessToken()]
     )
-    name = wtforms.StringField("Name", validators=[DataRequired()])
+    name = wtforms.StringField(
+        "Name", validators=[DataRequired(), ValidAsciiValues()]
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -28,5 +32,4 @@ class JoinLobbyForm(FlaskForm):
         # Cache the lobbies on the form so that the access token
         # validator can get them.
         self.lobbies = lobbies
-
         return super().validate()

--- a/hanabi/validators.py
+++ b/hanabi/validators.py
@@ -13,3 +13,28 @@ class ValidAccessToken:
         token = field.data
         if token not in lobbies:
             raise wtforms.ValidationError(self.message)
+
+
+def has_valid_asciis(word):
+    for char in word:
+        asc_val = ord(char)
+        if not (
+            48 <= asc_val <= 57 or 65 <= asc_val <= 90 or 97 <= asc_val <= 122
+        ):
+            return False
+    return True
+
+
+class ValidAsciiValues:
+    def __init__(self, message=None):
+        if not message:
+            message = (
+                "Requested username contains invalid characters "
+                "(must be letters or numbers)."
+            )
+        self.message = message
+
+    def __call__(self, form, field):
+        requested_player_id = field.data
+        if not has_valid_asciis(requested_player_id):
+            raise wtforms.ValidationError(self.message)

--- a/hanabi/validators.py
+++ b/hanabi/validators.py
@@ -15,12 +15,13 @@ class ValidAccessToken:
             raise wtforms.ValidationError(self.message)
 
 
+import string
+
+name_characters = string.ascii_letters + string.digits
+
 def has_valid_asciis(word):
     for char in word:
-        asc_val = ord(char)
-        if not (
-            48 <= asc_val <= 57 or 65 <= asc_val <= 90 or 97 <= asc_val <= 122
-        ):
+        if char not in name_characters:
             return False
     return True
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -16,14 +16,14 @@
 
         <div class="row justify-content-center">
           <div class="col-12 col-md-6 col-sm-4 form-group">
-            <label for="join-lobby-name">{{ join_form.name.label }}</label>
+            <label for="create-lobby-name">{{ create_form.name.label }}</label>
             <input class="form-control"
-                   id="join-lobby-name"
+                   id="create-lobby-name"
                    name="{{ join_form.name.name }}"
                    required>
-            {% if join_form.errors.name %}
-              <small id="join-lobby-name-error" class="form-text text-danger">
-                {{ ' '.join(join_form.errors.name) }}
+            {% if create_form.errors.name %}
+              <small id="create-lobby-name-error" class="form-text text-danger">
+                {{ ' '.join(create_form.errors.name) }}
               </small>
             {% endif %}
           </div>
@@ -35,7 +35,7 @@
       </form>
     </section>
 
-    <section class="mb-5" id="create-lobby">
+    <section class="mb-5" id="join-lobby">
       <h2 class="text-center">Join a Lobby</h2>
       <p class="text-center lead mb-4">
         Join a lobby that has already been created.


### PR DESCRIPTION
Refactored create-lobby name so errors only appeared for the corresponding boxes
resolves #13 