### PR TITLE
Persist form field values on error

### DIFF
--- a/hanabi/routes.py
+++ b/hanabi/routes.py
@@ -17,8 +17,8 @@ hanabi_lobbies = {}
 @app.route("/")
 @app.route("/home/")
 def main(create_form=None, join_form=None):
-    create_form = create_form or forms.CreateLobbyForm()
-    join_form = join_form or forms.JoinLobbyForm()
+    create_form = create_form or forms.CreateLobbyForm(prefix="create-lobby-")
+    join_form = join_form or forms.JoinLobbyForm(prefix="join-lobby-")
 
     return render_template(
         "main.html", create_form=create_form, join_form=join_form
@@ -70,7 +70,7 @@ def game_in_session(access_code, player_id):
 
 @app.route("/create-lobby/", methods=["post"])
 def create_lobby():
-    form = forms.CreateLobbyForm()
+    form = forms.CreateLobbyForm(prefix="create-lobby-")
     if not form.validate_on_submit():
         return main(create_form=form)
 
@@ -87,7 +87,7 @@ def create_lobby():
 
 @app.route("/join-lobby/", methods=["post"])
 def join_lobby():
-    form = forms.JoinLobbyForm()
+    form = forms.JoinLobbyForm(prefix="join-lobby-")
 
     if form.validate(hanabi_lobbies):
         access_token = form.access_token.data

--- a/hanabi/templates/main.html
+++ b/hanabi/templates/main.html
@@ -16,11 +16,8 @@
 
         <div class="row justify-content-center">
           <div class="col-12 col-md-6 col-sm-4 form-group">
-            <label for="create-lobby-name">{{ create_form.name.label }}</label>
-            <input class="form-control"
-                   id="create-lobby-name"
-                   name="{{ join_form.name.name }}"
-                   required>
+            {{ create_form.name.label }}
+            {{ create_form.name(class_='form-control', id='create-lobby-name') }}
             {% if create_form.errors.name %}
               <small id="create-lobby-name-error" class="form-text text-danger">
                 {{ ' '.join(create_form.errors.name) }}
@@ -46,11 +43,8 @@
 
         <div class="row">
           <div class="col form-group">
-            <label for="join-lobby-name">{{ join_form.name.label }}</label>
-            <input class="form-control"
-                   id="join-lobby-name"
-                   name="{{ join_form.name.name }}"
-                   required>
+            {{ join_form.name.label }}
+            {{ join_form.name(class_='form-control', id='join-lobby-name') }}
             {% if join_form.errors.name %}
               <small id="join-lobby-name-error" class="form-text text-danger">
                 {{ ' '.join(join_form.errors.name) }}
@@ -59,13 +53,8 @@
           </div>
 
           <div class="col form-group">
-            <label for="join-lobby-access-code">
-              {{ join_form.access_token.label }}
-            </label>
-            <input class="form-control"
-                   id="join-lobby-access-code"
-                   name="{{ join_form.access_token.name }}"
-                   required>
+            {{ join_form.access_token.label }}
+            {{ join_form.access_token(class='form-control') }}
             {% if join_form.errors.access_token %}
               <small id="join-lobby-access-token-error" class="form-text text-danger">
                 {{ ' '.join(join_form.errors.access_token) }}


### PR DESCRIPTION
When a form is submitted and it has validation errors, the resulting
page now keeps the values that the user has entered so that they only
have to fix the fields with errors.

This fix is made easier by taking advantage of WTForms provided HTML
rendering which eliminates a lot of the HTML we had provided ourselves.

Fixes #20