### PR TITLE
Add 0.0.0.0 to allowed hosts for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     image: hanabi-dev
 
     environment:
+      ALLOWED_HOSTS: 0.0.0.0
       DB_HOST: postgres
       DB_PASSWORD: password
     ports:


### PR DESCRIPTION
On machines where `0.0.0.0` is aliased to `localhost`, this allows for clicking on the link output by the development server to open the site.

@elijahlong5 you should make sure this actually works before merging it.