### PR TITLE
Add the ability to play a card

### DIFF
--- a/QuarantineHanabi.iml
+++ b/QuarantineHanabi.iml
@@ -29,13 +29,13 @@
     <orderEntry type="library" name="popper" level="application" />
   </component>
   <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
     <option name="myDocStringFormat" value="Google" />
   </component>
   <component name="TemplatesService">
     <option name="TEMPLATE_CONFIGURATION" value="Django" />
   </component>
   <component name="TestRunnerService">
-    <option name="projectConfiguration" value="pytest" />
     <option name="PROJECT_TEST_RUNNER" value="pytest" />
   </component>
 </module>

--- a/hanabi/game/api/serializers.py
+++ b/hanabi/game/api/serializers.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _, gettext
 from rest_framework import serializers
 
 from game import models
@@ -97,3 +98,94 @@ class GameStateOwnPlayerSerializer(serializers.ModelSerializer):
         fields = ("id", "cards", "name", "order")
         model = models.Player
         read_only_fields = fields
+
+
+class PlayActionSerializer(serializers.ModelSerializer):
+    card = GameStateCardSerializer(read_only=True)
+    card_id = serializers.PrimaryKeyRelatedField(
+        queryset=models.Card.objects.all(), write_only=True
+    )
+
+    class Meta:
+        fields = ("card", "card_id", "was_successful")
+        model = models.PlayAction
+        read_only_fields = ("was_successful",)
+
+
+class ActionSerializer(serializers.ModelSerializer):
+    DISCARD = "DISCARD"
+    DRAW = "DRAW"
+    HINT = "HINT"
+    ORDER_HAND = "ORDER_HAND"
+    PLAY = "PLAY"
+
+    ACTION_NAME_TO_INTERNAL_REP_MAP = {
+        DISCARD: models.Action.DISCARD,
+        DRAW: models.Action.DRAW,
+        HINT: models.Action.HINT,
+        ORDER_HAND: models.Action.ORDER_HAND,
+        PLAY: models.Action.PLAY,
+    }
+
+    type_choices = (
+        (DISCARD, _("Discard")),
+        (DRAW, _("Draw")),
+        (HINT, _("Hint")),
+        (ORDER_HAND, _("ORDER_HAND")),
+        (PLAY, _("Play")),
+    )
+
+    action_type = serializers.ChoiceField(choices=type_choices)
+    play_action = PlayActionSerializer()
+    player_name = serializers.CharField(source="player.name")
+
+    class Meta:
+        fields = (
+            "action_type",
+            "created_at",
+            "id",
+            "play_action",
+            "player_name",
+        )
+        model = models.Action
+        read_only_fields = ("created_at", "id")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._player = None
+
+    def create(self, validated_data):
+        action_type_name = validated_data.pop("action_type")
+        action_type = self.ACTION_NAME_TO_INTERNAL_REP_MAP[action_type_name]
+
+        action = models.Action.objects.create(
+            action_type=action_type,
+            game=self.context["game"],
+            player=self._player,
+        )
+
+        if action_type == models.Action.PLAY:
+            play_action = validated_data.pop("play_action", {})
+            # card_id exposes itself as an ID but is represented in
+            # Python as a full card object.
+            card = play_action.pop("card_id")
+
+            models.PlayAction.objects.create(
+                action=action,
+                card=card,
+                was_successful=self.context["game"].is_playable(card),
+            )
+            action.player.remove_card(card, action)
+
+        return action
+
+    def validate_player_name(self, name):
+        try:
+            self._player = models.Player.objects.get(
+                game=self.context["game"], lobby_member__name=name
+            )
+        except models.Player.DoesNotExist:
+            raise serializers.ValidationError(gettext("Invalid player name."))
+
+        return name

--- a/hanabi/game/api/test/views/test_actions_view.py
+++ b/hanabi/game/api/test/views/test_actions_view.py
@@ -1,0 +1,41 @@
+import requests
+from rest_framework import status
+
+from game import models
+
+
+def test_create_play_action(live_server):
+    lobby = models.Lobby.objects.create()
+    sean = lobby.members.create(name="Sean")
+    gus = lobby.members.create(name="Gus")
+
+    # Manually create a game so we control the cards
+    game = lobby.games.create(is_in_progress=True)
+    sean_player = game.players.create(lobby_member=sean, order=0)
+    gus_player = game.players.create(lobby_member=gus, order=1)
+
+    game.cards.create(color=models.Card.RED, deck_order=0, number=1)
+    game.cards.create(color=models.Card.BLUE, deck_order=1, number=1)
+
+    sean_player.give_card(game.draw_card(sean_player))
+    gus_player.give_card((game.draw_card(gus_player)))
+
+    # Send a play in
+    data = {
+        "action_type": "PLAY",
+        "player_name": sean_player.name,
+        "play_action": {"card_id": str(sean_player.cards[0].id)},
+    }
+    url = f"{live_server}/api/games/{game.id}/actions/"
+    response = requests.post(url, json=data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    action = response.json()
+
+    assert action["id"]
+    assert action["player_name"] == sean_player.name
+
+    play_action = action["play_action"]
+
+    assert play_action["was_successful"]

--- a/hanabi/game/api/test/views/test_actions_view.py
+++ b/hanabi/game/api/test/views/test_actions_view.py
@@ -1,10 +1,12 @@
+import pytest
 import requests
 from rest_framework import status
 
 from game import models
 
 
-def test_create_play_action(live_server):
+@pytest.fixture
+def two_card_game(db):
     lobby = models.Lobby.objects.create()
     sean = lobby.members.create(name="Sean")
     gus = lobby.members.create(name="Gus")
@@ -20,11 +22,17 @@ def test_create_play_action(live_server):
     sean_player.give_card(game.draw_card(sean_player))
     gus_player.give_card((game.draw_card(gus_player)))
 
+    return game, sean_player, gus_player
+
+
+def test_create_play_action(live_server, two_card_game):
+    game, sean, gus = two_card_game
+
     # Send a play in
     data = {
         "action_type": "PLAY",
-        "player_name": sean_player.name,
-        "play_action": {"card_id": str(sean_player.cards[0].id)},
+        "player_name": sean.name,
+        "play_action": {"card_id": str(sean.cards[0].id)},
     }
     url = f"{live_server}/api/games/{game.id}/actions/"
     response = requests.post(url, json=data)
@@ -34,8 +42,23 @@ def test_create_play_action(live_server):
     action = response.json()
 
     assert action["id"]
-    assert action["player_name"] == sean_player.name
+    assert action["player_name"] == sean.name
 
     play_action = action["play_action"]
 
     assert play_action["was_successful"]
+
+
+def test_create_play_action_wrong_turn(live_server, two_card_game):
+    game, sean, gus = two_card_game
+
+    # It should be Shawn's turn so a play from Gus should be rejected.
+    data = {
+        "action_type": "PLAY",
+        "player_name": gus.name,
+        "play_action": {"card_id": str(gus.cards[0].id)},
+    }
+    url = f"{live_server}/api/games/{game.id}/actions/"
+    response = requests.post(url, json=data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/hanabi/game/api/test/views/test_game_detail_view.py
+++ b/hanabi/game/api/test/views/test_game_detail_view.py
@@ -46,6 +46,7 @@ def test_get_game_with_valid_player_should_return_game_state(live_server):
     assert game_state["is_in_progress"]
 
     # Ensure game looks like a new game.
+    assert game_state["active_player"] == game.players.first().name
     assert game_state["remaining_bombs"] == 3
     assert game_state["remaining_cards"] == 40  # Each dealt 5 cards
 

--- a/hanabi/game/api/urls.py
+++ b/hanabi/game/api/urls.py
@@ -7,6 +7,11 @@ urlpatterns = [
     path(
         "games/<uuid:pk>/", views.GameDetailView.as_view(), name="game-detail"
     ),
+    path(
+        "games/<uuid:pk>/actions/",
+        views.ActionListCreateView.as_view(),
+        name="action-list",
+    ),
     path("lobbies/", views.LobbyCreateView.as_view(), name="lobby-list"),
     path(
         "lobbies/<code>/", views.LobbyDetailView.as_view(), name="detail-view",

--- a/hanabi/game/api/views.py
+++ b/hanabi/game/api/views.py
@@ -6,6 +6,19 @@ from game import models
 from game.api import serializers
 
 
+class ActionListCreateView(generics.CreateAPIView):
+    serializer_class = serializers.ActionSerializer
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+
+        context["game"] = get_object_or_404(
+            models.Game, pk=self.kwargs.get("pk")
+        )
+
+        return context
+
+
 class GameDetailView(generics.RetrieveAPIView):
     queryset = models.Game.objects.all()
     serializer_class = serializers.GameStateSerializer

--- a/hanabi/game/models/actions.py
+++ b/hanabi/game/models/actions.py
@@ -14,6 +14,11 @@ class Action(models.Model):
     ORDER_HAND = 4
     PLAY = 5
 
+    TURN_ACTION_TYPES = (DISCARD, HINT, PLAY)
+    """
+    The action types that cause a player's turn to be over.
+    """
+
     TYPE_CHOICES = (
         (DISCARD, _("Discard")),
         (DRAW, _("Draw")),

--- a/hanabi/game/models/games.py
+++ b/hanabi/game/models/games.py
@@ -120,3 +120,16 @@ class Game(models.Model):
         action = self.actions.create(action_type=Action.DRAW, player=player)
 
         return DrawAction.objects.create(action=action, card=card)
+
+    def is_playable(self, card):
+        if card.number == 1:
+            return not self.actions.filter(
+                play_action__card__color=card.color,
+                play_action__was_successful=True,
+            ).exists()
+
+        return self.actions.filter(
+            play_action__card__color=card.color,
+            play_action__card__number=card.number - 1,
+            play_action__was_successful=True,
+        ).exists()

--- a/hanabi/game/models/games.py
+++ b/hanabi/game/models/games.py
@@ -91,6 +91,36 @@ class Game(models.Model):
         return game
 
     @property
+    def active_player(self):
+        """
+        Returns:
+            The player that the game is waiting for a move from.
+        """
+        last_play = (
+            self.actions.filter(action_type__in=Action.TURN_ACTION_TYPES)
+            .order_by("-created_at")
+            .first()
+        )
+        ordered_players_query = self.players.order_by("order")
+
+        # If no turn-taking plays have happened yet, it is the first
+        # player's turn.
+        if not last_play:
+            return ordered_players_query.first()
+
+        # If there is no player whose turn comes after the previous
+        # player, then the game has wrapped back to the first player.
+        next_players_query = ordered_players_query.filter(
+            order__gt=last_play.player.order
+        )
+        if not next_players_query.exists():
+            return ordered_players_query.first
+
+        # If we are somewhere in the middle of the player order, return
+        # the player with next-highest order.
+        return next_players_query.first()
+
+    @property
     def remaining_bombs(self):
         failed_plays = self.actions.filter(
             play_action__was_successful=False
@@ -133,3 +163,17 @@ class Game(models.Model):
             play_action__card__number=card.number - 1,
             play_action__was_successful=True,
         ).exists()
+
+    def is_players_turn(self, player):
+        """
+        Determine if it is a specific player's turn.
+
+        Args:
+            player:
+                The player to compare to the active player.
+
+        Returns:
+            A boolean indicating if it is the provided player's turn.
+        """
+
+        return player == self.active_player

--- a/hanabi/game/models/players.py
+++ b/hanabi/game/models/players.py
@@ -67,6 +67,14 @@ class Player(models.Model):
         for card in cards:
             new_hand.cards.create(card=card)
 
+    def remove_card(self, card, source_action):
+        cards = self.cards
+        cards.remove(card)
+
+        new_hand = self.hands.create(source_action=source_action)
+        for card in cards:
+            new_hand.cards.create(card=card)
+
 
 class PlayerHand(models.Model):
 


### PR DESCRIPTION
Sending a `POST` request to `/api/games/<game_id>/actions/` allows for creating an action. For now, this is limited to playing a card.

The payload looks like:

```json
{
  "action_type": "PLAY",
  "player_name": "player",
  "play_action": {
    "card_id": "uuid-of-card-to-play"
  }
}
```